### PR TITLE
Use local email validation for contact form and update deps

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,9 +4,10 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel
 from typing import Optional
 import json
+import re
 from datetime import datetime
 
 FRONTEND_DIR = Path(__file__).parent / "frontend"
@@ -46,7 +47,7 @@ class ContactForm(BaseModel):
     subject: Optional[str] = None
     service_type: Optional[str] = None
     # Shared fields
-    email: EmailStr
+    email: str
     phone: Optional[str] = None
     message: str
 
@@ -61,6 +62,14 @@ contacts = []
 
 def normalize_optional(value: Optional[str]) -> Optional[str]:
     return (value or "").strip() or None
+
+
+EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+def is_valid_email(value: str) -> bool:
+    """Validate emails without requiring pydantic's optional email-validator package."""
+    return bool(EMAIL_RE.fullmatch(value.strip()))
 
 # Page routes
 @app.get("/")
@@ -152,6 +161,8 @@ def submit_contact_form(contact: ContactForm):
     email = str(contact.email).strip()
     if not email:
         raise HTTPException(status_code=422, detail="email is required")
+    if not is_valid_email(email):
+        raise HTTPException(status_code=422, detail="Please enter a valid email address")
 
     full_name = normalize_optional(contact.full_name) or normalize_optional(contact.name)
     if not full_name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
     "python-multipart>=0.0.6",
+    "email-validator>=2.0.0",
 ]
 
 [build-system]


### PR DESCRIPTION
### Motivation
- Avoid relying on `pydantic`'s `EmailStr` semantics (and its optional email-validator backing) by validating emails in-application. 
- Provide clearer validation errors for the `/api/contact` endpoint when an email is missing or malformed.

### Description
- Replaced `EmailStr` usage by changing the `ContactForm.email` field type to `str` and removed the `EmailStr` import. 
- Added an email regex and the helper `is_valid_email` function and imported `re` to perform simple email validation. 
- Added an explicit validation check in `POST /api/contact` to return a `422` with a friendly message when the email is empty or invalid. 
- Updated `pyproject.toml` to include `email-validator>=2.0.0` in `dependencies`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fca513888328a08bc806148ac352)